### PR TITLE
Integrate logback and audit logs in xml format

### DIFF
--- a/audit/pom.xml
+++ b/audit/pom.xml
@@ -9,8 +9,8 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>ch.svermeille.rika.config</groupId>
-    <artifactId>config</artifactId>
+    <groupId>ch.svermeille.rika.audit</groupId>
+    <artifactId>audit</artifactId>
 
     <properties>
         <maven.compiler.source>18</maven.compiler.source>
@@ -20,14 +20,30 @@
 
     <dependencies>
         <dependency>
-            <groupId>top.code2life</groupId>
-            <artifactId>spring-boot-dynamic-config</artifactId>
-            <version>1.0.9</version>
-        </dependency>
-        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.integration</groupId>
+            <artifactId>spring-integration-mqtt</artifactId>
+            <version>5.5.15</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.el</artifactId>
+            <version>3.0.1-b06</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.3.4</version>
         </dependency>
         <dependency>
             <groupId>com.google.flogger</groupId>
@@ -41,32 +57,17 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <optional>true</optional>
+            <groupId>com.google.flogger</groupId>
+            <artifactId>flogger-slf4j-backend</artifactId>
+            <version>0.7.4</version>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>ch.svermeille.rika.audit</groupId>
-            <artifactId>audit</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>ch.svermeille.rika.audit</groupId>
-            <artifactId>audit</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.11</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/audit/src/main/java/ch/svermeille/rika/audit/Actions.java
+++ b/audit/src/main/java/ch/svermeille/rika/audit/Actions.java
@@ -1,0 +1,16 @@
+package ch.svermeille.rika.audit;
+
+import java.util.logging.Level;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * @author Sebastien Vermeille
+ */
+@AllArgsConstructor
+@Getter
+public enum Actions {
+  CHANGED_CONFIGURATION(Level.WARNING);
+ 
+  private Level level;
+}

--- a/audit/src/main/java/ch/svermeille/rika/audit/AuditLogger.java
+++ b/audit/src/main/java/ch/svermeille/rika/audit/AuditLogger.java
@@ -1,0 +1,39 @@
+package ch.svermeille.rika.audit;
+
+import java.io.StringWriter;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import lombok.NonNull;
+import lombok.extern.flogger.Flogger;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author Sebastien Vermeille
+ */
+@Service
+@Flogger
+public class AuditLogger {
+
+  public void audit(@NonNull AuditedAction auditedAction){
+    try {
+      final var jaxbContext = JAXBContext.newInstance(AuditedAction.class);
+      final var jaxbMarshaller = jaxbContext.createMarshaller();
+      jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
+      jaxbMarshaller.setProperty(Marshaller.JAXB_FRAGMENT, Boolean.TRUE);
+      StringWriter sw = new StringWriter();
+      jaxbMarshaller.marshal(auditedAction, sw);
+      String xmlString = sw.toString();
+
+      log
+          .at(auditedAction.getAction().getLevel())
+          .log(xmlString);
+
+    } catch(JAXBException e) {
+      log.atSevere()
+          .withCause(e)
+          .log("Could not serialize {}", auditedAction);
+    }
+  }
+
+}

--- a/audit/src/main/java/ch/svermeille/rika/audit/AuditedAction.java
+++ b/audit/src/main/java/ch/svermeille/rika/audit/AuditedAction.java
@@ -1,0 +1,75 @@
+package ch.svermeille.rika.audit;
+
+import static lombok.AccessLevel.PACKAGE;
+
+import java.util.Map;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+/**
+ * @author Sebastien Vermeille
+ */
+@Getter
+@EqualsAndHashCode
+@ToString
+@XmlRootElement(name = "audited-action")
+@NoArgsConstructor(access = PACKAGE)
+public class AuditedAction {
+
+  @XmlAttribute(name = "action")
+  private Actions action;
+
+  @XmlElement(name = "metadata")
+  private Map<String, Object> props;
+
+  private AuditedAction(final Builder builder) {
+    action = builder.action;
+    props = builder.props;
+  }
+
+  public static IAction builder() {
+    return new Builder();
+  }
+
+
+  public interface IBuild {
+    AuditedAction build();
+  }
+
+  public interface IProps {
+    IBuild withProps(Map<String, Object> val);
+  }
+
+  public interface IAction {
+    IProps withAction(Actions val);
+  }
+
+  public static final class Builder implements IProps, IAction, IBuild {
+    private Map<String, Object> props;
+    private Actions action;
+
+    private Builder() {
+    }
+
+    @Override
+    public IBuild withProps(final Map<String, Object> val) {
+      props = val;
+      return this;
+    }
+
+    @Override
+    public IProps withAction(final Actions val) {
+      action = val;
+      return this;
+    }
+
+    public AuditedAction build() {
+      return new AuditedAction(this);
+    }
+  }
+}

--- a/audit/src/main/java/ch/svermeille/rika/audit/xml/AuditXmlLayout.java
+++ b/audit/src/main/java/ch/svermeille/rika/audit/xml/AuditXmlLayout.java
@@ -1,0 +1,57 @@
+package ch.svermeille.rika.audit.xml;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.LayoutBase;
+
+/**
+ * @author Sebastien Vermeille
+ */
+public class AuditXmlLayout extends LayoutBase<ILoggingEvent> {
+
+  private static final int DEFAULT_SIZE = 256;
+  private static final int UPPER_LIMIT = 2048;
+
+  private StringBuilder buf = new StringBuilder(DEFAULT_SIZE);
+
+  @Override
+  public void start() {
+    super.start();
+  }
+
+  /**
+   * Formats a {@link ILoggingEvent} in conformity with the log4j.dtd.
+   */
+  @Override
+  public String doLayout(final ILoggingEvent event) {
+
+    // Reset working buffer. If the buffer is too large, then we need a new
+    // one in order to avoid the penalty of creating a large array.
+    if(this.buf.capacity() > UPPER_LIMIT) {
+      this.buf = new StringBuilder(DEFAULT_SIZE);
+    } else {
+      this.buf.setLength(0);
+    }
+
+    // We yield to the \r\n heresy.
+
+    this.buf.append("<audit");
+    this.buf.append(" timestamp=\"");
+    this.buf.append(event.getTimeStamp());
+    this.buf.append("\" level=\"");
+    this.buf.append(event.getLevel());
+    this.buf.append("\"");
+    this.buf.append(">\r\n");
+    this.buf.append("    ");
+    this.buf.append(event.getFormattedMessage());
+
+    this.buf.append("\r\n</audit>\r\n");
+
+    return this.buf.toString();
+  }
+
+  @Override
+  public String getContentType() {
+    return "text/xml";
+  }
+
+}

--- a/audit/src/main/java/ch/svermeille/rika/audit/xml/LocalDateTimeAdapter.java
+++ b/audit/src/main/java/ch/svermeille/rika/audit/xml/LocalDateTimeAdapter.java
@@ -1,0 +1,22 @@
+package ch.svermeille.rika.audit.xml;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+
+/**
+ * @author Sebastien Vermeille
+ */
+public class LocalDateTimeAdapter extends XmlAdapter<String, LocalDateTime> {
+  private final DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+  @Override
+  public String marshal(final LocalDateTime dateTime) {
+    return dateTime.format(this.dateFormat);
+  }
+
+  @Override
+  public LocalDateTime unmarshal(final String dateTime) {
+    return LocalDateTime.parse(dateTime, this.dateFormat);
+  }
+}

--- a/bridge/pom.xml
+++ b/bridge/pom.xml
@@ -40,6 +40,18 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>com.google.flogger</groupId>
+            <artifactId>flogger-slf4j-backend</artifactId>
+            <version>0.7.4</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.11</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>
@@ -48,6 +60,12 @@
             <groupId>top.code2life</groupId>
             <artifactId>spring-boot-dynamic-config</artifactId>
             <version>1.0.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.el</artifactId>
+            <version>3.0.1-b06</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>ch.svermeille.rika.mqtt</groupId>

--- a/bridge/src/main/java/ch/svermeille/rika/Rika2MqttApplication.java
+++ b/bridge/src/main/java/ch/svermeille/rika/Rika2MqttApplication.java
@@ -15,6 +15,7 @@ public class Rika2MqttApplication {
 	private static ConfigurableApplicationContext context;
 
 	public static void main(String[] args) {
+		System.setProperty("flogger.backend_factory", "com.google.common.flogger.backend.slf4j.Slf4jBackendFactory#getInstance");
 		context = SpringApplication.run(Rika2MqttApplication.class, args);
 	}
 

--- a/bridge/src/main/java/ch/svermeille/rika/bridge/Bridge.java
+++ b/bridge/src/main/java/ch/svermeille/rika/bridge/Bridge.java
@@ -43,43 +43,40 @@ public class Bridge {
   @PostConstruct
   void init() {
     log.atInfo().log("Initializing Rika2Mqtt bridge :");
-    stoveIds.clear();
-    stoveIds.addAll(rikaFirenetService.getStoves());
+    this.stoveIds.clear();
+    this.stoveIds.addAll(this.rikaFirenetService.getStoves());
 
-    var maskedEmailAccount = emailObfuscator.maskEmailAddress(rikaEmailAccount);
-    if(stoveIds.isEmpty()) {
+    final var maskedEmailAccount = this.emailObfuscator.maskEmailAddress(this.rikaEmailAccount);
+    if(this.stoveIds.isEmpty()) {
       log.atSevere().log("Could not retrieve any stove linked with account %s. Nothing to do here the application will shutdown. Please " +
           "double-check your configuration.", maskedEmailAccount); // TODO:
     } else {
-      log.atInfo().log("Found %s stoves linked with account %s.", stoveIds.size(), maskedEmailAccount);
+      log.atInfo().log("Found %s stoves linked with account %s.", this.stoveIds.size(), maskedEmailAccount);
     }
 
     log.atInfo().log("Will now retrieve status for declared stove(s) each %s and publish it back to mqtt.",
-        bridgeReportInterval);
+        this.bridgeReportInterval);
 
     publishToMqtt();
   }
 
   @Scheduled(fixedDelayString = "${bridge.reportInterval}")
   void publishToMqtt() {
-    stoveIds.forEach(stoveId -> {
-      final StoveStatus status;
-
+    this.stoveIds.forEach(stoveId -> {
       try {
-        status = rikaFirenetService.getStatus(stoveId);
-        Gson gson = new Gson();
-        mqttService.publish(gson.toJson(status));
-      } catch(InvalidStoveIdException e) {
+        final StoveStatus status = this.rikaFirenetService.getStatus(stoveId);
+        final Gson gson = new Gson();
+        this.mqttService.publish(gson.toJson(status));
+      } catch(final InvalidStoveIdException e) {
         log.atSevere().log(e.getMessage(), e);
         // TODO: maybe remove this id from the list ? and ask a getStoves() to have it up to date and avoid infinite loop ?
         // this way it could support the use case you somehow sell your stove and have it no longer under your account
-      } catch(CouldNotAuthenticateToRikaFirenetException e) {
+      } catch(final CouldNotAuthenticateToRikaFirenetException e) {
         log.atSevere().log(e.getMessage(), e);
         // TODO: should maybe have a retry mechanism? or perform a shutdown ?
-      } catch(UnableToRetrieveRikaFirenetDataException e) {
+      } catch(final UnableToRetrieveRikaFirenetDataException e) {
         log.atSevere().log(e.getMessage(), e);
       }
     });
-
   }
 }

--- a/bridge/src/main/resources/logback.xml
+++ b/bridge/src/main/resources/logback.xml
@@ -1,0 +1,65 @@
+<configuration>
+    <property name="LOG_ROOT" value="logs" />
+    <property name="XML_LOG_FILE" value="audit" />
+
+    <contextName>rika2mqtt</contextName>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date{ISO8601} %-5level [%thread, %X{traceId}, %X{spanId}] %logger{36} %X{akkaSource} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>logs/rika2mqtt.log</file>
+        <append>true</append>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>logs/rika2mqtt-%d{yyyy-MM-dd,GMT}.log.gz</fileNamePattern>
+        </rollingPolicy>
+
+        <encoder>
+            <pattern>%date{yyyy-MM-dd HH:mm:ss,GMT} %level [%thread] %logger.%method\(%line\) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNC-STDOUT" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="STDOUT"/>
+    </appender>
+
+    <appender name="ASYNC-FILE" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="FILE"/>
+    </appender>
+
+    <appender name="AUDIT-XML-LOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_ROOT}/${XML_LOG_FILE}.xml</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <!-- daily rollover -->
+            <fileNamePattern>${LOG_ROOT}/${XML_LOG_FILE}-%d{yyyy-MM-dd}.%i.xml.gz</fileNamePattern>
+            <!-- each archived file's size will be max 10MB -->
+            <maxFileSize>10MB</maxFileSize>
+            <!-- 30 days to keep -->
+            <maxHistory>30</maxHistory>
+            <!-- total size of all archive files, if total size > 100GB, it will delete old archived file -->
+            <totalSizeCap>300MB</totalSizeCap>
+        </rollingPolicy>
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <charset>UTF-8</charset>
+            <layout class="ch.svermeille.rika.audit.xml.AuditXmlLayout">
+                <locationInfo>false</locationInfo>
+                <properties>false</properties>
+            </layout>
+        </encoder>
+    </appender>
+
+    <logger name="ch.svermeille.rika.audit.AuditLogger" level="DEBUG" additivity="false">
+        <appender-ref ref="AUDIT-XML-LOG"/>
+    </logger>
+
+    <logger name="org.quartz.core.QuartzSchedulerThread" level="WARN"/>
+
+    <root level="DEBUG">
+        <appender-ref ref="ASYNC-FILE"/>
+        <appender-ref ref="ASYNC-STDOUT"/>
+    </root>
+</configuration>

--- a/config/src/main/java/ch/svermeille/rika/config/listener/ConfigChangeListener.java
+++ b/config/src/main/java/ch/svermeille/rika/config/listener/ConfigChangeListener.java
@@ -1,8 +1,12 @@
 package ch.svermeille.rika.config.listener;
 
+import ch.svermeille.rika.audit.Actions;
+import ch.svermeille.rika.audit.AuditLogger;
+import ch.svermeille.rika.audit.AuditedAction;
 import ch.svermeille.rika.config.event.ConfigurationChangeRequireRestartEvent;
 import java.util.Set;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.flogger.Flogger;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -12,9 +16,11 @@ import top.code2life.config.ConfigurationChangedEvent;
  * @author Sebastien Vermeille
  */
 @Component
+@RequiredArgsConstructor
 @Flogger
 public class ConfigChangeListener {
 
+  private final AuditLogger auditLogger;
   static final Set<String> PROPS_REQUIRE_RESTART = Set.of(
       "bridge.reportInterval",
       "rika.email",
@@ -33,6 +39,13 @@ public class ConfigChangeListener {
   public ConfigurationChangeRequireRestartEvent onConfigurationChanged(@NonNull ConfigurationChangedEvent event) {
     final var diffs = event.getDiff();
     final var requireRestart = PROPS_REQUIRE_RESTART.stream().anyMatch(diffs.keySet()::contains);
+
+    auditLogger.audit(AuditedAction.builder()
+        .withAction(Actions.CHANGED_CONFIGURATION)
+        .withProps(diffs)
+        .build()
+    );
+
     if(requireRestart){
       log.atInfo().log();
       return new ConfigurationChangeRequireRestartEvent(

--- a/mqtt/pom.xml
+++ b/mqtt/pom.xml
@@ -41,9 +41,27 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>com.google.flogger</groupId>
+            <artifactId>flogger-slf4j-backend</artifactId>
+            <version>0.7.4</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.11</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
             <version>8.0.0.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.el</artifactId>
+            <version>3.0.1-b06</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>top.code2life</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
         <module>bridge</module>
         <module>mqtt</module>
         <module>config</module>
+        <module>audit</module>
     </modules>
 
     <dependencies>
@@ -37,6 +38,12 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.el</artifactId>
+            <version>3.0.1-b06</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/rika-firenet/pom.xml
+++ b/rika-firenet/pom.xml
@@ -42,6 +42,18 @@
             <version>0.7.4</version>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.flogger</groupId>
+            <artifactId>flogger-slf4j-backend</artifactId>
+            <version>0.7.4</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.11</version>
+            <scope>compile</scope>
+        </dependency>
 
         <dependency>
             <groupId>com.squareup.retrofit2</groupId>


### PR DESCRIPTION
That way we can benefit from logback maturity regarding:
* rolling log files, 
* purging logs when larger than given size
* compressing old logs 

out of the box (just a matter of parameters in logback.xml)

This way the ui part integrating audits just have to parse the xml logs but the persistence is based on a mature logging framework