### PR TITLE
#12 Create a docker image tag per release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 on:
   release:
-    types: [created]
+    types: [ created ]
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -27,15 +27,6 @@ jobs:
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD_OSSRH }}
           MAVEN_OPTS: "--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED"
           GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
-#      - name: Set up Java for publishing to GitHub Packages
-#        uses: actions/setup-java@v3
-#        with:
-#          java-version: '20'
-#          distribution: 'temurin'
-#      - name: Publish to GitHub Packages
-#        run: mvn --batch-mode deploy
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -50,4 +41,4 @@ jobs:
         with:
           context: .
           push: true
-          tags: cookiecodedev/rika2mqtt:latest
+          tags: cookiecodedev/rika2mqtt:latest, cookiecodedev/rika2mqtt:${{ github.event.release.name }}

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,5 @@
-* Docker image -> when doing a new release tag latest + @tag (currently only latest)
+# TODO
+
 * Local run fail ... mqtt exception -> define int tests
 * Github workflows for external contributors, they can't run sonar analysis this is an issue.
 * Evaluate dependabot -> can't run sonar analysis this is an issue


### PR DESCRIPTION
# Feature https://github.com/sebastienvermeille/rika2mqtt/issues/12 

## Changes
When doing a release create a docker tag per release. (Currently on `latest`)
That way specific versions of the docker can be used