### PR TITLE
Add google analytics to rika2mqtt.cookiecode.dev (documentation)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -26,5 +26,6 @@
       "versions": {
         "stable": "2.0.0"
       }
-    }
+    },
+    "googleAnalytics": "G-5K9CY84T71",
 }


### PR DESCRIPTION
As maintainer of the project, I do not gather a lot of information about the usage. 

This google analytics tag will provide information about the documentation and is just measuring visits. I could not find any free alternative that I don't have to host at the moment.