### PR TITLE
Fix lifecycle issue in the CI pipelines

### DIFF
--- a/bridge/pom.xml
+++ b/bridge/pom.xml
@@ -78,7 +78,7 @@
         <executions>
           <execution>
             <id>copy-rename-file</id>
-            <phase>install</phase>
+            <phase>package</phase>
             <goals>
               <goal>copy</goal>
             </goals>


### PR DESCRIPTION
The CI is using package and not install therefore this plugin were never executed and then the rika2mqtt.jar could not be found by the Dockerfile