### PR TITLE
Use retry mechanism for rika remote control management

### DIFF
--- a/.licenses/licenses.xml
+++ b/.licenses/licenses.xml
@@ -55,6 +55,7 @@
       <names>
         <name>Eclipse Public License - v2.0</name>
         <name>Eclipse Public License - Version 2.0</name>
+        <name>Eclipse Public License - v 2.0</name>
         <name>EPL 2.0</name>
       </names>
       <urls>

--- a/rika-firenet/pom.xml
+++ b/rika-firenet/pom.xml
@@ -49,6 +49,8 @@
     <okhttp3.version>4.12.0</okhttp3.version>
     <httpclient5.version>5.3.1</httpclient5.version>
     <jsoup.version>1.17.2</jsoup.version>
+    <spring-retry.version>2.0.3</spring-retry.version>
+    <spring-aspects.version>6.0.11</spring-aspects.version>
 
     <!-- test dependencies version -->
     <mockserver.client.version>5.15.0</mockserver.client.version>
@@ -101,7 +103,16 @@
       <artifactId>mapstruct</artifactId>
       <version>${mapstruct.version}</version>
     </dependency>
-
+    <dependency>
+      <groupId>org.springframework.retry</groupId>
+      <artifactId>spring-retry</artifactId>
+      <version>${spring-retry.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-aspects</artifactId>
+      <version>${spring-aspects.version}</version>
+    </dependency>
     <!-- test dependencies -->
     <dependency>
       <groupId>org.testcontainers</groupId>

--- a/rika-firenet/src/main/java/dev/cookiecode/rika2mqtt/rika/firenet/configuration/RikaFirenetConfiguration.java
+++ b/rika-firenet/src/main/java/dev/cookiecode/rika2mqtt/rika/firenet/configuration/RikaFirenetConfiguration.java
@@ -24,6 +24,7 @@ package dev.cookiecode.rika2mqtt.rika.firenet.configuration;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 /**
@@ -31,5 +32,6 @@ import org.springframework.scheduling.annotation.EnableScheduling;
  */
 @Configuration
 @EnableScheduling
+@EnableRetry
 @EnableConfigurationProperties(RikaFirenetConfigProperties.class)
 public class RikaFirenetConfiguration {}


### PR DESCRIPTION
That way we can expect a better handling in case of in-between operations performed by a tier device

:+1: Tested locally ready for test in docker latest channel 